### PR TITLE
add clarity to existing problems in asking questions workshop

### DIFF
--- a/asking-questions/index.html
+++ b/asking-questions/index.html
@@ -82,7 +82,9 @@
             </p>
           </li>
           <li id="fallback" class="problem">
-            <p>What colour is this text?</p>
+            <p>This text has the ruleset <code>#fallback { color: var(--black); }</code></p>
+
+            Why is this paragraph <em>not</em> a different colour to all the others?
           </li>
           <li id="boolean" class="problem">
             <p>There's a transition on this text. Why isn't it working?</p>
@@ -92,9 +94,7 @@
           </li>
           <li id="grid" class="problem">
             <p>
-              Before running Lighthouse, write down the errors it will give you
-              on this page. Now
-              <a href="https://validator.w3.org/">validate the HTML</a>.
+              Use the Sources panel of the dev tools to inspect the HTML of this page and - before validating the markup - write down what errors it will give you. Now <a href="https://validator.w3.org/">validate the HTML</a>.
             </p>
           </li>
           <li id="hundred" class="problem">


### PR DESCRIPTION
This PR makes two changes to the [Asking Questions workshop page](https://cyf-workshop.netlify.app/asking-questions/). They are both based on the idea that these problems should be something 

1. The "What colour is this text?" problems is fleshed out. As it stands, it is the same colour as the rest of the text content of the page because it references a CSS variable that doesn't exist. You could determine this by looking at the dev tools, but otherwise it is very difficult for a trainee to make a meaningful prediction when all you know is that the text is the same colour as everything else. The update tells trainees it references a variable to give them something to base a prediction on.
2. One of the tasks references predicting errors shown by Lighthouse and the HTML validator. The reference to Lighthouse is removed*, since the only issue it flags is a missing meta description tag for SEO purposes, whilst the [W3 HTML Validator](https://validator.w3.org/#validate_by_uri) gives a more pertinent (and potentially predictable) error of a duplicated ID. The wording is also cleared up a little.

*If someone feels strongly that Lighthouse should be included here and they should run the page through both that and the HTML validator then I'm open to that!